### PR TITLE
feat: expand e2e ci tests to minimum and insiders

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,6 +12,9 @@ on:
         # Note: To re-run `lint-commits` after fixing the PR title, close-and-reopen the PR.
         branches: [main, feature/*]
 
+permissions:
+    contents: read
+
 # Cancel old jobs when a pull request is updated.
 concurrency:
     group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Notes:

- Expand e2e ci tests to minimum and insiders
---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
