### PR TITLE
fix: remove duplicate ci builds when raised from feature branch to main

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
     push:
-        branches: [main, feature/*]
+        branches: [main]
     pull_request:
         # By default, CI will trigger on opened/synchronize/reopened event types.
         # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
