### PR TITLE
fix: block inline request flowing to lsp if connection is not valid

### DIFF
--- a/packages/amazonq/src/app/inline/completion.ts
+++ b/packages/amazonq/src/app/inline/completion.ts
@@ -38,6 +38,7 @@ import {
     toIdeDiagnostics,
     handleExtraBrackets,
     InlineCompletionLoggingReason,
+    AuthUtil,
 } from 'aws-core-vscode/codewhisperer'
 import { LineTracker } from './stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from './tutorials/inlineTutorialAnnotation'
@@ -346,6 +347,11 @@ export class AmazonQInlineCompletionItemProvider implements InlineCompletionItem
         token: CancellationToken,
         getAllRecommendationsOptions?: GetAllRecommendationsOptions
     ): Promise<InlineCompletionItem[]> {
+        if (!AuthUtil.instance.isConnectionValid()) {
+            getLogger().warn('Inline completion skipped: connection is not valid or has expired')
+            return []
+        }
+
         if (vsCodeState.isCodeWhispererEditing) {
             getLogger().info('Q is editing, returning empty')
             return []

--- a/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
+++ b/packages/amazonq/test/unit/amazonq/apps/inline/completion.test.ts
@@ -25,6 +25,7 @@ import {
     ReferenceHoverProvider,
     ReferenceLogViewProvider,
     vsCodeState,
+    AuthUtil,
 } from 'aws-core-vscode/codewhisperer'
 import { LineTracker } from '../../../../../src/app/inline/stateTracker/lineTracker'
 import { InlineTutorialAnnotation } from '../../../../../src/app/inline/tutorials/inlineTutorialAnnotation'
@@ -253,6 +254,7 @@ describe('InlineCompletionManager', () => {
                 recommendationService = new RecommendationService(mockSessionManager)
                 documentEventListener = new DocumentEventListener()
                 vsCodeState.isRecommendationsActive = false
+                sandbox.stub(AuthUtil.instance, 'isConnectionValid').returns(true)
                 mockSessionManager = {
                     getActiveSession: getActiveSessionStub,
                     getActiveRecommendation: getActiveRecommendationStub,


### PR DESCRIPTION
## Problem
Kibena suggests over 70% of `codewhisperer_serviceInvocation` metrics were caused by `AccessDenied`

## Solution

Suspecting due to some unexpected path, the credential didnt' get refreshed correctly and by design, auto inline suggestion will be fired every few key strokes. Currently LSP seems to lack a mechanism to determine if a provided token is expired or not.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
