### PR TITLE
feat: link to new AWS Transform plugin

### DIFF
--- a/packages/amazonq/.changes/next-release/Feature-55913bf6-6fc3-4a5e-8aba-72c1cba44026.json
+++ b/packages/amazonq/.changes/next-release/Feature-55913bf6-6fc3-4a5e-8aba-72c1cba44026.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Link users to new AWS Transform VS Code plugin and Kiro Power"
+}

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -51,7 +51,7 @@ export const TabTypeDataMap: Record<Exclude<TabType, 'welcome'>, TabTypeData> = 
         title: 'Q - Code Transformation',
         placeholder: 'Open a new tab to chat with Q',
         welcome:
-            'Welcome to Code Transformation!\n\n> **ℹ️ AWS Transform custom now available for Java upgrades. Agentic AI that handles version upgrades, SDK migration, and more, and improves with every execution. [Learn more](https://aws.amazon.com/transform/custom/)**',
+            'Welcome to Code Transformation!\n\n> **ℹ️ AWS Transform custom now available for Java upgrades. Agentic AI that handles version upgrades, SDK migration, and more, and improves with every execution. [Learn more](https://aws.amazon.com/transform/custom/)**\n\n> **🆕 See the [AWS Transform VS Code plugin](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-transform-plugin) and [AWS Transform Kiro Power](https://github.com/kirodotdev/powers/tree/main/aws-transform).**',
     },
     review: {
         title: 'Q - Review',


### PR DESCRIPTION
Link users to AWS Transform VS Code plugin and AWS Transform Kiro Power.


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
