### PR TITLE
fix: re-show startup toast on every IDE launch until dismissed

### DIFF
--- a/packages/core/src/notifications/controller.ts
+++ b/packages/core/src/notifications/controller.ts
@@ -71,14 +71,14 @@ export class NotificationsController {
     }
 
     public pollForStartUp() {
-        return this.poll('startUp')
+        return this.poll('startUp', true)
     }
 
     public pollForEmergencies() {
-        return this.poll('emergency')
+        return this.poll('emergency', false)
     }
 
-    private async poll(category: NotificationType) {
+    private async poll(category: NotificationType, isStartUpPoll: boolean = false) {
         try {
             // Get latest state in case it was modified by other windows.
             // It is a minimal read to avoid race conditions.
@@ -88,10 +88,10 @@ export class NotificationsController {
             logger.error(`Unable to fetch %s notifications: %s`, category, err)
         }
 
-        await this.displayNotifications()
+        await this.displayNotifications(isStartUpPoll)
     }
 
-    private async displayNotifications() {
+    private async displayNotifications(isStartUpPoll: boolean = false) {
         const ruleEngine = new RuleEngine(await this.ruleContextFn())
         const dismissed = new Set(this.state.dismissed)
         const startUp =
@@ -110,14 +110,22 @@ export class NotificationsController {
         const newEmergency = emergency.filter(wasNewlyReceived)
         const newlyReceived = [...newStartUp, ...newEmergency]
 
-        if (newlyReceived.length > 0) {
-            await this.notificationsNode.onReceiveNotifications(newlyReceived)
-            // remove displayed notifications from newlyReceived
-            this.state.newlyReceived = this.state.newlyReceived.filter((id) => !newlyReceived.some((n) => n.id === id))
-            await this.writeState()
+        // On startup poll, re-show toast for ALL undismissed startup notifications
+        // so users see the notification on every IDE launch until they explicitly dismiss it.
+        const startUpToToast = isStartUpPoll ? startUp : newStartUp
+        const toToast = [...startUpToToast, ...newEmergency]
+
+        if (toToast.length > 0) {
+            await this.notificationsNode.onReceiveNotifications(toToast, (id) => this.dismissNotification(id))
             if (newEmergency.length > 0) {
                 void this.notificationsNode.focusPanel()
             }
+        }
+
+        // Remove newly received IDs after processing (still needed for emergency dedup)
+        if (newlyReceived.length > 0) {
+            this.state.newlyReceived = this.state.newlyReceived.filter((id) => !newlyReceived.some((n) => n.id === id))
+            await this.writeState()
         }
     }
 

--- a/packages/core/src/notifications/panelNode.ts
+++ b/packages/core/src/notifications/panelNode.ts
@@ -203,13 +203,21 @@ export class NotificationsNode implements TreeNode {
     private showInformationWindow(
         notification: ToolkitNotification,
         type: OnReceiveType = 'toast',
-        passive: boolean = false
+        passive: boolean = false,
+        dismissFn?: (id: string) => Promise<void>
     ) {
         const isModal = type === 'modal'
 
         // modal has to have defined actions (buttons)
         const buttons = notification.uiRenderInstructions.actions ?? []
         const buttonLabels = buttons.map((actions) => actions.displayText['en-US'])
+
+        // Add a "Dismiss" button for startup notifications shown as toasts
+        const dismissLabel = 'Dismiss'
+        if (!isModal && dismissFn) {
+            buttonLabels.push(dismissLabel)
+        }
+
         const detail = notification.uiRenderInstructions.content['en-US'].description
 
         // we use toastPreview to display as title for toast, since detail won't be shown
@@ -234,6 +242,11 @@ export class NotificationsNode implements TreeNode {
                         source: getNotificationTelemetryId(notification),
                         action: response ?? 'OK',
                     })
+                    if (response === dismissLabel && dismissFn) {
+                        span.record({ action: 'dismiss' })
+                        await dismissFn(notification.id)
+                        return
+                    }
                     if (response) {
                         const selectedButton = buttons.find((actions) => actions.displayText['en-US'] === response)
                         // Different button options
@@ -268,9 +281,12 @@ export class NotificationsNode implements TreeNode {
             })
     }
 
-    public async onReceiveNotifications(notifications: ToolkitNotification[]) {
+    public async onReceiveNotifications(
+        notifications: ToolkitNotification[],
+        dismissFn?: (id: string) => Promise<void>
+    ) {
         for (const notification of notifications) {
-            void this.showInformationWindow(notification, notification.uiRenderInstructions.onReceive, true)
+            void this.showInformationWindow(notification, notification.uiRenderInstructions.onReceive, true, dismissFn)
         }
     }
 


### PR DESCRIPTION
## What

Two changes to startup notification behavior:

1. **Persistent toast** — startup notifications now re-show their toast on every IDE launch until the user explicitly dismisses them.
2. **Dismiss button on toast** — a "Dismiss" button is added directly to the toast popup, so users can dismiss without navigating to the notifications panel.

## Why

For important notifications like end-of-support notices, users need to see the notification repeatedly until they acknowledge it. Previously:
- The toast only fired once (when first received), subsequent launches only showed it in the sidebar panel
- The only way to dismiss was via the notifications panel tree view, which most users never find

## How

**controller.ts:**
- `pollForStartUp()` passes `isStartUpPoll=true` to `displayNotifications()`
- When `isStartUpPoll` is true, the toast fires for ALL undismissed startup notifications — not just "newly received" ones
- Passes a `dismissFn` callback to `onReceiveNotifications` to avoid circular imports

**panelNode.ts:**
- `onReceiveNotifications()` accepts an optional `dismissFn` callback
- `showInformationWindow()` appends a "Dismiss" button to non-modal toasts when `dismissFn` is provided
- Clicking "Dismiss" invokes the callback which persists the notification ID in `state.dismissed[]`

## Behavior summary

| Scenario | Before | After |
|----------|--------|-------|
| First launch after notification published | Toast fires (no dismiss button) | Toast fires with "Learn more" + "Dismiss" buttons |
| Subsequent launch (not dismissed) | No toast, only in panel | Toast fires again with both buttons |
| User clicks "Dismiss" on toast | N/A | Persisted, no more toasts |
| User clicks x on toast (close without action) | Toast gone forever | Toast reappears on next launch |
| After dismiss (via toast or panel) | No toast, not in panel | No toast, not in panel |

## Testing

1. Install the VSIX (point to integ channel for e2e, or use Developer Menu to inject a notification)
2. Launch VS Code — toast should appear with "Learn more" and "Dismiss" buttons
3. Click x to close (not dismiss) — quit (`Cmd+Q`) and relaunch — toast should appear again
4. Click "Dismiss" — quit and relaunch — toast should NOT appear
5. To reset: Developer Menu -> Reset feature state -> Notifications

## Screenshots

Tested locally — toast shows both buttons, dismiss persists across restarts, close-without-action re-toasts on next launch.
