### PR TITLE
docs: update sunset notification message and Learn More URL

### DIFF
--- a/packages/amazonq/.changes/next-release/Removal-f132c58c-ea42-477b-b0f5-fdc95b7f1798.json
+++ b/packages/amazonq/.changes/next-release/Removal-f132c58c-ea42-477b-b0f5-fdc95b7f1798.json
@@ -1,0 +1,4 @@
+{
+	"type": "Removal",
+	"description": "Add UI surfacing Amazon Q Developer plugins end-of-support notice to users"
+}

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -107,11 +107,9 @@
                         <span class="maintenance-banner__text">
                             <!-- TODO: finalize banner text and Learn more URL with product team -->
                             Amazon Q Developer IDE plugins will reach end of support on April 30, 2027. New accounts
-                            will no longer be available starting 5/15, but existing users can still sign-in below.
-                            <a
-                                class="maintenance-banner__link"
-                                href="https://aws.amazon.com/q/developer/"
-                                @click="handleLearnMoreClick"
+                            will no longer be available starting May 15, 2026, but existing users can still sign-in
+                            below.
+                            <a class="maintenance-banner__link" href="https://kiro.dev/" @click="handleLearnMoreClick"
                                 >Learn more</a
                             >
                         </span>

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -109,7 +109,10 @@
                             Amazon Q Developer IDE plugins will reach end of support on April 30, 2027. New accounts
                             will no longer be available starting May 15, 2026, but existing users can still sign-in
                             below.
-                            <a class="maintenance-banner__link" href="https://kiro.dev/" @click="handleLearnMoreClick"
+                            <a
+                                class="maintenance-banner__link"
+                                href="https://aws.amazon.com/blogs/devops/amazon-q-developer-end-of-support-announcement/"
+                                @click="handleLearnMoreClick"
                                 >Learn more</a
                             >
                         </span>

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -105,7 +105,6 @@
                             </svg>
                         </span>
                         <span class="maintenance-banner__text">
-                            <!-- TODO: finalize banner text and Learn more URL with product team -->
                             Amazon Q Developer IDE plugins will reach end of support on April 30, 2027. New accounts
                             will no longer be available starting May 15, 2026, but existing users can still sign-in
                             below.


### PR DESCRIPTION
## Summary

Update the sunset notification message and Learn More URL in the login webview.

**Message change:** `starting 5/15` → `starting May 15, 2026`
**URL change:** `https://aws.amazon.com/q/developer/` → `https://kiro.dev/`

> Note: URL will be updated again once the final destination is confirmed.

## Files changed
- `packages/core/src/login/webview/vue/login.vue` — banner text + href
