### PR TITLE
fix: Validate persisted region profile before restoring on startup

### DIFF
--- a/packages/amazonq/test/unit/codewhisperer/region/regionProfileManager.test.ts
+++ b/packages/amazonq/test/unit/codewhisperer/region/regionProfileManager.test.ts
@@ -183,7 +183,7 @@ describe('RegionProfileManager', function () {
         })
 
         it(`restoreRegionProfile`, async function () {
-            sinon.stub(sut, 'listRegionProfile').resolves([profileFoo])
+            sinon.stub(sut, 'getProfiles').resolves([profileFoo])
             await setupConnection('idc')
             const conn = authUtil.conn
             if (!conn) {
@@ -198,6 +198,67 @@ describe('RegionProfileManager', function () {
             await sut.restoreRegionProfile(conn)
 
             assert.strictEqual(sut.activeRegionProfile, profileFoo)
+        })
+
+        it(`restoreRegionProfile clears stale profile when no longer available`, async function () {
+            sinon.stub(sut, 'getProfiles').resolves([
+                {
+                    name: 'other-profile',
+                    region: 'us-east-1',
+                    arn: 'other arn',
+                    description: 'other',
+                },
+            ])
+            await setupConnection('idc')
+            const conn = authUtil.conn
+            if (!conn) {
+                fail('connection should not be undefined')
+            }
+
+            const state = {} as any
+            state[conn.id] = profileFoo
+
+            await globals.globalState.update('aws.amazonq.regionProfiles', state)
+
+            await sut.restoreRegionProfile(conn)
+
+            // Profile should NOT be restored since it's no longer available
+            assert.strictEqual(sut.activeRegionProfile, undefined)
+
+            // Persisted state should be cleared
+            const persistedState = globals.globalState.tryGet<{ [label: string]: RegionProfile }>(
+                'aws.amazonq.regionProfiles',
+                Object,
+                {}
+            )
+            assert.strictEqual(persistedState[conn.id], undefined)
+        })
+
+        it(`restoreRegionProfile skips restore when profile listing fails`, async function () {
+            sinon.stub(sut, 'getProfiles').rejects(new Error('stale SSO token'))
+            await setupConnection('idc')
+            const conn = authUtil.conn
+            if (!conn) {
+                fail('connection should not be undefined')
+            }
+
+            const state = {} as any
+            state[conn.id] = profileFoo
+
+            await globals.globalState.update('aws.amazonq.regionProfiles', state)
+
+            await sut.restoreRegionProfile(conn)
+
+            // Profile should NOT be restored when we can't validate
+            assert.strictEqual(sut.activeRegionProfile, undefined)
+
+            // Persisted state should be preserved (not cleared) — profile might still be valid on next restart
+            const persistedState = globals.globalState.tryGet<{ [label: string]: RegionProfile }>(
+                'aws.amazonq.regionProfiles',
+                Object,
+                {}
+            )
+            assert.deepStrictEqual(persistedState[conn.id], profileFoo)
         })
     })
 

--- a/packages/core/src/codewhisperer/region/regionProfileManager.ts
+++ b/packages/core/src/codewhisperer/region/regionProfileManager.ts
@@ -287,6 +287,26 @@ export class RegionProfileManager {
             return
         }
 
+        // Validate the persisted profile still exists before blindly restoring it.
+        // Without this check, stale SSO tokens + a persisted profile ARN that is no
+        // longer valid causes "We couldn't load your Q developer profiles" errors
+        try {
+            const availableProfiles = await this.getProfiles()
+            const stillValid = availableProfiles.some((p) => p.arn === previousSelected.arn)
+            if (!stillValid) {
+                RegionProfileManager.logger.warn(
+                    `Persisted profile '${previousSelected.name}' (${previousSelected.region}) is no longer available, clearing stale state`
+                )
+                await this.invalidateProfile(previousSelected.arn)
+                return
+            }
+        } catch (e) {
+            // If we can't list profiles (e.g. stale token), don't blindly restore —
+            // let the user re-authenticate and re-select instead of showing a broken state.
+            RegionProfileManager.logger.warn(`Failed to validate persisted profile on restore: ${(e as Error).message}`)
+            return
+        }
+
         await this.switchRegionProfile(previousSelected, 'reload')
     }
 


### PR DESCRIPTION
## Problem

Users hit "We couldn't load your Q developer profiles" errors after the extension auto-updated to v2.0.0. The workaround required exiting VS Code, renaming `~/.aws`, signing out of IAM Identity Center, and relaunching.

### Root cause: 

`restoreRegionProfile()` blindly restores a persisted profile ARN from `globalState` on startup without validating it against the current `listAvailableProfiles()` results. When three conditions align — stale SSO cached token, persisted profile ARN in globalState, and same connection ID on re-auth — the extension enters a broken state where the profile selector shows an error instead of letting the user re-select.

This is a pre-existing bug, not a v2.0.0 regression. The timing correlation with the release was coincidental (likely triggered by an upstream IdP/SSO change at the customer's org).

## Solution

Added validation in `restoreRegionProfile()` before applying the persisted profile:

1. Call `getProfiles()` (cached, 1hr TTL) to fetch current available profiles
2. If the persisted ARN is not in the list → call `invalidateProfile()` to clear stale state, skip restore
3. If `getProfiles()` throws (stale token) → log warning, skip restore, let user re-authenticate cleanly

## Tests

- Existing `restoreRegionProfile` test still passes (happy path: profile exists in API response)
- New: `restoreRegionProfile clears stale profile when no longer available` — persisted profile not in API response → state cleared
- New: `restoreRegionProfile skips restore when profile listing fails` — API throws → no blind restore


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
