### PR TITLE
deps: remove unused @kubernetes/client-node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22776,46 +22776,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@kubernetes/client-node": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.20.0.tgz",
-            "integrity": "sha512-xxlv5GLX4FVR/dDKEsmi4SPeuB49aRc35stndyxcC73XnUEEwF39vXbROpHOirmDse8WE9vxOjABnSVS+jb7EA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/js-yaml": "^4.0.1",
-                "@types/node": "^20.1.1",
-                "@types/request": "^2.47.1",
-                "@types/ws": "^8.5.3",
-                "byline": "^5.0.0",
-                "isomorphic-ws": "^5.0.0",
-                "js-yaml": "^4.1.0",
-                "jsonpath-plus": "^7.2.0",
-                "request": "^2.88.0",
-                "rfc4648": "^1.3.0",
-                "stream-buffers": "^3.0.2",
-                "tar": "^6.1.11",
-                "tslib": "^2.4.1",
-                "ws": "^8.11.0"
-            },
-            "optionalDependencies": {
-                "openid-client": "^5.3.0"
-            }
-        },
-        "node_modules/@kubernetes/client-node/node_modules/@types/node": {
-            "version": "20.19.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-            "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.21.0"
-            }
-        },
-        "node_modules/@kubernetes/client-node/node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "license": "MIT"
-        },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.4",
             "dev": true,
@@ -24422,12 +24382,6 @@
                 "@types/responselike": "*"
             }
         },
-        "node_modules/@types/caseless": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
-            "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-            "license": "MIT"
-        },
         "node_modules/@types/circular-dependency-plugin": {
             "version": "5.0.8",
             "dev": true,
@@ -24549,6 +24503,7 @@
         },
         "node_modules/@types/js-yaml": {
             "version": "4.0.5",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/jsdom": {
@@ -24681,35 +24636,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/request": {
-            "version": "2.48.13",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
-            "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/caseless": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*",
-                "form-data": "^2.5.5"
-            }
-        },
-        "node_modules/@types/request/node_modules/form-data": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-            "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.35",
-                "safe-buffer": "^5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
         "node_modules/@types/responselike": {
             "version": "1.0.0",
             "license": "MIT",
@@ -24795,6 +24721,7 @@
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/uuid": {
@@ -24831,6 +24758,7 @@
         },
         "node_modules/@types/ws": {
             "version": "8.5.5",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -25773,6 +25701,7 @@
         },
         "node_modules/ajv": {
             "version": "6.12.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -25993,15 +25922,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
         "node_modules/asn1.js": {
             "version": "5.4.1",
             "license": "MIT",
@@ -26028,15 +25948,6 @@
                 "util": "^0.12.5"
             }
         },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/ast-types": {
             "version": "0.9.14",
             "dev": true,
@@ -26055,6 +25966,7 @@
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/available-typed-arrays": {
@@ -26222,15 +26134,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/aws-ssm-document-language-service": {
             "version": "1.0.0",
             "license": "Apache-2.0",
@@ -26378,12 +26281,6 @@
             "version": "1.0.8",
             "license": "MIT"
         },
-        "node_modules/aws4": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-            "license": "MIT"
-        },
         "node_modules/azure-devops-node-api": {
             "version": "11.2.0",
             "dev": true,
@@ -26481,15 +26378,6 @@
             "version": "0.6.1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -26781,15 +26669,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/byline": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-            "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "license": "MIT",
@@ -26998,12 +26877,6 @@
                 }
             ],
             "license": "CC-BY-4.0"
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-            "license": "Apache-2.0"
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -27355,6 +27228,7 @@
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
@@ -27769,18 +27643,6 @@
                 "type": "^1.0.1"
             }
         },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/data-urls": {
             "version": "5.0.0",
             "dev": true,
@@ -27956,6 +27818,7 @@
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -28177,16 +28040,6 @@
             "version": "0.2.0",
             "license": "MIT"
         },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "license": "MIT",
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "dev": true,
@@ -28354,21 +28207,6 @@
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -29119,21 +28957,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "license": "MIT"
-        },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT"
-        },
         "node_modules/fancy-log": {
             "version": "1.3.3",
             "license": "MIT",
@@ -29182,6 +29005,7 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
@@ -29457,15 +29281,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "dev": true,
@@ -29514,30 +29329,6 @@
             },
             "engines": {
                 "node": ">=14.14"
-            }
-        },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/fs-monkey": {
@@ -29742,15 +29533,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "node_modules/github-from-package": {
             "version": "0.0.0",
             "license": "MIT"
@@ -29920,29 +29702,6 @@
             "version": "2.0.1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "deprecated": "this library is no longer supported",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/hard-rejection": {
             "version": "2.1.0",
@@ -30303,21 +30062,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
             }
         },
         "node_modules/http2": {
@@ -30885,12 +30629,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-            "license": "MIT"
-        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
             "dev": true,
@@ -30954,21 +30692,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/isomorphic-ws": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-            "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "ws": "*"
-            }
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-            "license": "MIT"
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -31089,12 +30812,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-            "license": "MIT"
-        },
         "node_modules/jsdom": {
             "version": "23.0.1",
             "dev": true,
@@ -31193,12 +30910,6 @@
             "version": "2.3.1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-            "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-schema-to-typescript": {
             "version": "13.1.1",
@@ -31300,18 +31011,13 @@
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "license": "ISC"
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -31344,30 +31050,6 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonpath-plus": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-            "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
             }
         },
         "node_modules/jszip": {
@@ -31750,7 +31432,7 @@
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -32135,31 +31817,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/mkdirp": {
@@ -32712,30 +32369,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/object-hash": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-            "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/object-inspect": {
@@ -32790,16 +32428,6 @@
             "version": "1.1.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/oidc-token-hash": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
-            "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": "^10.13.0 || >=12.0.0"
-            }
         },
         "node_modules/on-finished": {
             "version": "2.4.1",
@@ -32866,32 +32494,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/openid-client": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
-            "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "jose": "^4.15.9",
-                "lru-cache": "^6.0.0",
-                "object-hash": "^2.2.0",
-                "oidc-token-hash": "^5.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/panva"
-            }
-        },
-        "node_modules/openid-client/node_modules/jose": {
-            "version": "4.15.9",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-            "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-            "license": "MIT",
-            "optional": true,
-            "funding": {
-                "url": "https://github.com/sponsors/panva"
             }
         },
         "node_modules/optionator": {
@@ -33186,12 +32788,6 @@
         "node_modules/pend": {
             "version": "1.2.0",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -33627,6 +33223,7 @@
         },
         "node_modules/psl": {
             "version": "1.9.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/public-encrypt": {
@@ -34184,38 +33781,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/request-light": {
             "version": "0.2.5",
             "license": "MIT",
@@ -34271,52 +33836,6 @@
         "node_modules/request-light/node_modules/vscode-nls": {
             "version": "4.1.2",
             "license": "MIT"
-        },
-        "node_modules/request/node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
-        "node_modules/request/node_modules/qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/request/node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/request/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "license": "MIT",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -34452,12 +33971,6 @@
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/rfc4648": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
-            "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
-            "license": "MIT"
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
@@ -35147,31 +34660,6 @@
             "version": "1.0.3",
             "license": "BSD-3-Clause"
         },
-        "node_modules/sshpk": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-            "license": "MIT",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/stack-trace": {
             "version": "0.0.10",
             "license": "MIT",
@@ -35546,23 +35034,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "license": "ISC",
-            "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/tar-fs": {
             "version": "2.1.1",
             "license": "MIT",
@@ -35585,36 +35056,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/tar/node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/tar/node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tar/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/tcp-port-used": {
@@ -36048,12 +35489,6 @@
                 "node": "*"
             }
         },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "license": "Unlicense"
-        },
         "node_modules/type": {
             "version": "1.2.0",
             "dev": true,
@@ -36264,6 +35699,7 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -36398,26 +35834,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "node_modules/verror/node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-            "license": "MIT"
         },
         "node_modules/vinyl": {
             "version": "2.2.1",
@@ -37433,6 +36849,7 @@
         },
         "node_modules/yallist": {
             "version": "4.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/yaml": {
@@ -37763,7 +37180,6 @@
                 "@aws/mynah-ui": "^4.35.4",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@iarna/toml": "^2.2.5",
-                "@kubernetes/client-node": "^0.20.0",
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/middleware-retry": "^4.0.3",
                 "@smithy/node-http-handler": "^4.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -626,7 +626,6 @@
         "@aws/mynah-ui": "^4.35.4",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@iarna/toml": "^2.2.5",
-        "@kubernetes/client-node": "^0.20.0",
         "@smithy/fetch-http-handler": "^5.0.1",
         "@smithy/middleware-retry": "^4.0.3",
         "@smithy/node-http-handler": "^4.0.2",


### PR DESCRIPTION
## Problem

`@kubernetes/client-node` is declared as a runtime dependency in `packages/core` (`aws-core-vscode`) but is **not imported anywhere** in the codebase. It exists only as a `package.json` entry.

It pulls in the transitive dependency `jsonpath-plus@7.2.0`, which is affected by [CVE-2025-1302](https://nvd.nist.gov/vuln/detail/CVE-2025-1302) (RCE, fixed in `jsonpath-plus >= 10.3.0`), along with the long-deprecated `request` library and a number of other now-unused transitive packages.

## Change

- Remove `@kubernetes/client-node` from `packages/core/package.json`.
- Regenerate `package-lock.json`, which removes `@kubernetes/client-node` and its entire transitive subtree — including `jsonpath-plus`, `request`, `openid-client@5`, `tar@6`, and related dead packages.

Because nothing references `@kubernetes/client-node`, this has no effect on runtime behavior and simply drops dead weight plus a vulnerable transitive dependency.

## Verification

- Searched the repository for `@kubernetes/client-node` imports, `KubeConfig`, and dynamic `require(...)` usage — no source references exist (only the `package.json` declaration).
- `npm install --package-lock-only` regenerates the lockfile with no source changes.
- Net diff: 3 files changed, removing the dependency and its locked subtree.
