### PR TITLE
deps: resolve newly-expanded Dependabot security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24906,11 +24906,13 @@
             }
         },
         "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 6"
+                "node": ">= 10"
             }
         },
         "node_modules/@ts-morph/common": {
@@ -27380,7 +27382,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -28850,9 +28854,9 @@
             "license": "MIT"
         },
         "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
@@ -30569,20 +30573,21 @@
             "license": "MIT"
         },
         "node_modules/glob": {
-            "version": "10.3.10",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -30614,15 +30619,6 @@
             },
             "peerDependencies": {
                 "tslib": "2"
-            }
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/glob/node_modules/minimatch": {
@@ -31228,7 +31224,9 @@
             "license": "MIT"
         },
         "node_modules/immutable": {
-            "version": "4.3.0",
+            "version": "4.3.8",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+            "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
             "license": "MIT"
         },
         "node_modules/import-fresh": {
@@ -31689,13 +31687,12 @@
             }
         },
         "node_modules/jackspeak": {
-            "version": "2.3.6",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -32109,9 +32106,9 @@
             }
         },
         "node_modules/koa": {
-            "version": "2.16.2",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
-            "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
+            "version": "2.16.4",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+            "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -33092,14 +33089,6 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/mocha/node_modules/diff": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
         "node_modules/mocha/node_modules/glob": {
             "version": "7.2.0",
             "dev": true,
@@ -33119,17 +33108,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -33141,6 +33119,17 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/mocha/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/mocha/node_modules/js-yaml": {
@@ -33167,7 +33156,9 @@
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.0.1",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+            "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -33769,7 +33760,6 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "dev": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pako": {
@@ -33921,25 +33911,26 @@
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "1.10.1",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "lru-cache": "^9.1.1 || ^10.0.0",
+                "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=16 || 14 >=14.18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.1.0",
-            "license": "ISC",
-            "engines": {
-                "node": "14 || >=16.14"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
         },
         "node_modules/path-to-regexp": {
             "version": "1.9.0",
@@ -36897,7 +36888,9 @@
             }
         },
         "node_modules/ts-node/node_modules/diff": {
-            "version": "4.0.2",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -37421,9 +37414,9 @@
             }
         },
         "node_modules/vscode-languageclient/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+            "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -38529,7 +38522,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "1.10.2",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "license": "ISC",
             "engines": {
                 "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -82,21 +82,28 @@
         "vscode-nls-dev": "^4.0.4"
     },
     "overrides": {
+        "@tootallnate/once": "2.0.1",
         "@xmldom/xmldom": "0.8.13",
+        "brace-expansion@1": "1.1.13",
         "cipher-base": "1.0.5",
+        "diff@4": "4.0.4",
+        "diff@5": "5.2.2",
         "enhanced-resolve": "5.17.1",
         "fast-uri": "3.1.2",
         "fast-xml-parser": "5.7.0",
         "flatted": "3.4.2",
         "follow-redirects": "1.16.0",
         "form-data": "4.0.6",
+        "glob@10": "10.5.0",
+        "immutable": "4.3.8",
         "js-yaml@4": "4.2.0",
         "jsonata": "2.2.1",
-        "koa": "2.16.2",
+        "koa": "2.16.4",
         "launch-editor": "2.14.1",
         "linkify-it": "5.0.1",
         "lodash": "4.18.0",
         "markdown-it": "14.2.0",
+        "minimatch@5": "5.1.8",
         "morgan": "1.11.0",
         "node-forge": "1.4.0",
         "on-headers": "1.1.0",
@@ -109,6 +116,7 @@
         "shell-quote": "1.8.4",
         "tmp": "0.2.7",
         "undici": "6.27.0",
-        "ws": "8.21.0"
+        "ws": "8.21.0",
+        "yaml": "1.10.3"
     }
 }


### PR DESCRIPTION
## Problem

After the earlier security PRs (#136/#137/#138) merged, several Dependabot
alerts re-surfaced because their **advisories were expanded to new version
lines** (or newly published) — re-flagging packages at versions the earlier PRs
didn't target. Example: the `uuid` advisory added `< 11.1.1`; `yaml` added
`< 1.10.3`; a **new `koa` CVE** needs `2.16.4`.

## Solution

Resolve the **10 cleanly-fixable** alerts with the same safe overrides approach,
verified against the **current** advisory ranges. Root lockfile only; verified
idempotent.

| Alert(s) | Package | Fix | Notes |
| --- | --- | --- | --- |
| #99, #246 | `koa` | 2.16.2 → **2.16.4** | new CVE |
| #214 | `@tootallnate/once` | → **2.0.1** | |
| #170, #20 | `brace-expansion` (1.x) | → **1.1.13** | version-scoped (`@1`) |
| #157 | `yaml` | → **1.10.3** | expanded to 1.x line |
| #131 | `immutable` | → **4.3.8** | expanded to 4.x line |
| #106 | `minimatch` (5.x) | → **5.1.8** | version-scoped (`@5`) |
| #55 | `diff` | 4.x→**4.0.4**, 5.x→**5.2.2** | version-scoped |
| #36 | `glob` (10.x) | → **10.5.0** | version-scoped (`@10`) |

Version-scoped overrides (`pkg@major`) are used where multiple major lines
coexist, so unaffected lines aren't disturbed.

### Deferred: `uuid` (#217, #219, #220)

Not included — these need a **major `uuid` 9 → 11** bump, which is genuinely
risky here:
- `uuid` is a **direct dependency of the generated `src.gen` clients** (`^9.0.1`),
  and npm **ignores an override on a direct dependency** unless the spec matches
  exactly (so it stays 9.0.1).
- In root, npm won't dedupe the hoisted `uuid@9.0.1` shared across older
  `@aws-sdk` clients via `@smithy/middleware-retry` (verified with
  `--package-lock-only`, a real reify, and `npm dedupe`).
- A proper fix also touches the generated clients + `@types/uuid` and needs
  build validation. Left for a dedicated follow-up.

### Verification

- All 10 alerts confirmed **RESOLVED** by cross-checking installed versions
  against the current (expanded) advisory ranges.
- Root `package-lock.json` verified **idempotent**.

> **Draft:** opened as a draft for CI validation.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
