### PR TITLE
deps: fix critical websocket-driver advisory (#247)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38161,7 +38161,9 @@
             }
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
         "shell-quote": "1.8.4",
         "tmp": "0.2.7",
         "undici": "6.27.0",
+        "websocket-driver": "0.7.5",
         "ws": "8.21.0",
         "yaml": "1.10.3"
     }


### PR DESCRIPTION
## Problem

New **critical** Dependabot alert **#247**: `websocket-driver` < 0.7.5 (GHSA-xv26-6w52-cph6, "message corruption via abuse of protocol length headers"). It's a **transitive, dev-scope** dependency (via `sockjs` / `faye-websocket`, from webpack-dev-server).

## Solution

Add an npm `overrides` entry pinning `websocket-driver` to **0.7.5** (single version in the tree; patched version). Root `package-lock.json` only.

### Verification
- `websocket-driver` resolves to **0.7.5** in the lockfile.
- Lockfile verified **idempotent**.

> **Draft:** opened as a draft for CI validation.

---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/amazon-q-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.