### PR TITLE
test: bump @vscode/test-electron to ^3.1.0 to fix macOS insiders CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "@typescript-eslint/eslint-plugin": "^7.14.1",
                 "@typescript-eslint/parser": "^7.14.1",
                 "@vscode/codicons": "^0.0.33",
-                "@vscode/test-electron": "^2.5.2",
+                "@vscode/test-electron": "^3.1.0",
                 "@vscode/test-web": "^0.0.65",
                 "@vscode/vsce": "^2.19.0",
                 "adm-zip": "^0.6.0",
@@ -25674,9 +25674,9 @@
             "license": "MIT"
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+            "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -25687,7 +25687,7 @@
                 "semver": "^7.6.2"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=22"
             }
         },
         "node_modules/@vscode/test-web": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "@typescript-eslint/eslint-plugin": "^7.14.1",
                 "@typescript-eslint/parser": "^7.14.1",
                 "@vscode/codicons": "^0.0.33",
-                "@vscode/test-electron": "^2.3.8",
+                "@vscode/test-electron": "^2.5.2",
                 "@vscode/test-web": "^0.0.65",
                 "@vscode/vsce": "^2.19.0",
                 "adm-zip": "^0.6.0",
@@ -24907,16 +24907,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@ts-morph/common": {
             "version": "0.24.0",
             "dev": true,
@@ -25684,14 +25674,17 @@
             "license": "MIT"
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.3.8",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.5",
                 "jszip": "^3.10.1",
-                "semver": "^7.5.2"
+                "ora": "^8.1.0",
+                "semver": "^7.6.2"
             },
             "engines": {
                 "node": ">=16"
@@ -25733,14 +25726,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/@vscode/test-web/node_modules/agent-base": {
-            "version": "7.1.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/@vscode/test-web/node_modules/balanced-match": {
@@ -25789,30 +25774,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/test-web/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@vscode/test-web/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/@vscode/test-web/node_modules/jackspeak": {
@@ -26435,14 +26396,13 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "debug": "4"
-            },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -27986,6 +27946,35 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cliui": {
@@ -30498,6 +30487,19 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -31055,16 +31057,17 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/http-proxy-middleware": {
@@ -31124,15 +31127,17 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.0",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -31500,6 +31505,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-interactive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-nan": {
             "version": "1.3.2",
             "dev": true,
@@ -31820,41 +31838,6 @@
                 "canvas": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jsdom/node_modules/agent-base": {
-            "version": "7.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/jsdom/node_modules/http-proxy-agent": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/jsdom/node_modules/https-proxy-agent": {
-            "version": "7.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/jsesc": {
@@ -32769,6 +32752,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mimic-response": {
@@ -33695,6 +33691,140 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/ora": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+            "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "cli-cursor": "^5.0.0",
+                "cli-spinners": "^2.9.2",
+                "is-interactive": "^2.0.0",
+                "is-unicode-supported": "^2.0.0",
+                "log-symbols": "^6.0.0",
+                "stdin-discarder": "^0.2.2",
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ora/node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/log-symbols": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "is-unicode-supported": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/os-browserify": {
@@ -35279,6 +35409,52 @@
                 "lowercase-keys": "^2.0.0"
             }
         },
+        "node_modules/restore-cursor": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/restore-cursor/node_modules/onetime": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/restore-cursor/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/restructure": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
@@ -36122,6 +36298,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/stdin-discarder": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/stream-browserify": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
         "@vscode/codicons": "^0.0.33",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/test-web": "^0.0.65",
         "@vscode/vsce": "^2.19.0",
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
         "@vscode/codicons": "^0.0.33",
-        "@vscode/test-electron": "^2.3.8",
+        "@vscode/test-electron": "^2.5.2",
         "@vscode/test-web": "^0.0.65",
         "@vscode/vsce": "^2.19.0",
         "adm-zip": "^0.6.0",

--- a/packages/core/scripts/test/launchTestUtilities.ts
+++ b/packages/core/scripts/test/launchTestUtilities.ts
@@ -5,11 +5,14 @@
 
 import * as proc from 'child_process' // eslint-disable-line no-restricted-imports
 import packageJson from '../../package.json'
-import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron'
+import {
+    downloadAndUnzipVSCode,
+    resolveCliArgsFromVSCodeExecutablePath,
+    runTests,
+    TestOptions,
+} from '@vscode/test-electron'
 import { join, resolve } from 'path'
-import { runTests } from '@vscode/test-electron'
 import { VSCODE_EXTENSION_ID } from '../../src/shared/extensions'
-import { TestOptions } from '@vscode/test-electron/out/runTest'
 
 const envvarVscodeTestVersion = 'VSCODE_TEST_VERSION'
 


### PR DESCRIPTION
## Problem

The `test macOS (18.x, insiders)` job fails repo-wide (on `main` and on unrelated PRs, e.g. #204) with:

```
Test error: Error: spawn ./Visual Studio Code - Insiders.app/Contents/MacOS/Electron ENOENT
```

`@vscode/test-electron` 2.x resolves a macOS **Insiders** executable path that current Insiders builds no longer use. Bumping within the 2.x line (`2.3.8 → 2.5.2`) does **not** fix it — `2.5.2` is the last 2.x release (2024) and predates the layout change (CI-confirmed).

## Fix

Bump `@vscode/test-electron` `^2.5.2 → ^3.1.0` — the line that handles the current Insiders macOS layout. This mirrors upstream `aws/aws-toolkit-vscode`, which already ships `^3.1.0`.

- `package.json`: `@vscode/test-electron` → `^3.1.0`
- `packages/core/scripts/test/launchTestUtilities.ts`: import `TestOptions` / `runTests` from the package root and drop the internal `@vscode/test-electron/out/runTest` path (the root export is the public API in 3.x).
- `package-lock.json`: regenerated (integrity matches the registry).

## No CI Node bump required

An earlier revision of this PR assumed 3.x forces a Node 18 → 22 CI migration. It does **not**:

- `.npmrc` sets `engine-strict=false`, so 3.x (`engines: node>=22`) installs on the Node 18 runners.
- Upstream `aws-toolkit-vscode` ships `@vscode/test-electron@^3.1.0` while keeping macOS/Linux CI on Node 18.

## Verification

- `npm install` resolves `@vscode/test-electron@3.1.0` (integrity matches registry).
- `tsc -p packages/core/tsconfig.json --noEmit` → 0 errors (the import restructure type-checks).
- macOS Insiders behavior confirmed by CI on this PR.
